### PR TITLE
Angular Version: allow the use of double quotes for the version field

### DIFF
--- a/Extensions/Versioning/VersionAngularFileTask/src/AppyVersionToAngularFileFunctions.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/src/AppyVersionToAngularFileFunctions.ts
@@ -99,7 +99,7 @@ export function ProcessFile(file, field, newVersion) {
     } else {
         if (field && field.length > 0) {
             console.log (`Updating the field '${field}' version`);
-            const versionRegex = `(${field}:.*')(.*)(')`;
+            const versionRegex = `(${field}:.*["'])(.*)(["'])`;
             var regexp = new RegExp(versionRegex, "gmi");
             let content: string = filecontent.toString();
             let matches;


### PR DESCRIPTION
### What problem does this PR address?

Allows the use of double quotes in the `environment.ts` file to be versioned.
